### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "essentialcontacts",
     "name_pretty": "Essential Contacts API",
     "product_documentation": "https://cloud.google.com/resource-manager/docs/managing-notification-contacts/",
-    "client_documentation": "https://googleapis.dev/python/essentialcontacts/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/essentialcontacts/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ services, such as Cloud Billing, by providing your own list of contacts.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-essential-contacts.svg
    :target: https://pypi.org/project/google-cloud-essential-contacts/
 .. _Essential Contacts API: https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
-.. _Client Library Documentation: https://googleapis.dev/python/essentialcontacts/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/essentialcontacts/latest
 .. _Product Documentation:  https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.